### PR TITLE
Fix a deprecation brought by Rails 2.3.9

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,2 +1,2 @@
 require File.join(File.dirname(__FILE__), *%w[.. lib viewtastic])
-ActiveSupport::Dependencies.load_paths << File.join(Rails.root, *%w[app presenters])
+ActiveSupport::Dependencies.autoload_paths << File.join(Rails.root, *%w[app presenters])

--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,2 +1,7 @@
 require File.join(File.dirname(__FILE__), *%w[.. lib viewtastic])
-ActiveSupport::Dependencies.autoload_paths << File.join(Rails.root, *%w[app presenters])
+
+if Rails.version >= '2.3.9'
+  ActiveSupport::Dependencies.autoload_paths
+else
+  ActiveSupport::Dependencies.load_paths
+end << File.join(Rails.root, *%w[app presenters])


### PR DESCRIPTION
I hate deprecation warnings, so I made a quick fix for viewtastic.
